### PR TITLE
Don't filter instance list before sending to Nomad

### DIFF
--- a/plugin/multipass.go
+++ b/plugin/multipass.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
@@ -229,13 +228,10 @@ func (t *TargetPlugin) scaleIn(
 		multipassInstanceNames[i] = instance.GetName()
 	}
 
-	slices.Sort(multipassInstanceNames)
-	targeted := multipassInstanceNames[0:delta]
-
 	nodes, err := t.clusterUtils.RunPreScaleInTasksWithRemoteCheck(
 		context.Background(),
 		config,
-		targeted,
+		multipassInstanceNames,
 		int(delta),
 	)
 	if err != nil {


### PR DESCRIPTION
The original idea here was to force the oldest auto-scaled instance to be removed during a scale-in event. The primary issue with this is that the Nomad autoscaler will never scale-in the node it is running on. This can lead to a situation – I'd imagine quite commonly, in fact – where the autoscaler is on the oldest node, which prevents the scale-in event from succeeding.

There are some workarounds that aren't simply giving up and ceding full control over which node is removed to Nomad, but rather than attempt any of those here, it would make more sense to add a new Node Selector Strategy to the autoscaler in a PR.

References:

- https://developer.hashicorp.com/nomad/tools/autoscaling/concepts/policy-eval/node-selector-strategy
- https://github.com/hashicorp/nomad-autoscaler/tree/main/sdk/helper/scaleutils/nodeselector